### PR TITLE
Increase countdown timer to 15 seconds

### DIFF
--- a/components/BananaMath/MonkeyMath.tsx
+++ b/components/BananaMath/MonkeyMath.tsx
@@ -14,7 +14,7 @@ function getRandomNumber(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1)) + min
 }
 
-const COUNT_DOWN_TIME = 5
+const COUNT_DOWN_TIME = 15
 
 export default function MonkeyMath() {
   // State variables


### PR DESCRIPTION
Changed COUNT_DOWN_TIME from 5 to 15 to give users more time to answer questions in the MonkeyMath component.